### PR TITLE
Fix Vercel backend entrypoint

### DIFF
--- a/aiva-backend/README.MD
+++ b/aiva-backend/README.MD
@@ -115,15 +115,24 @@ To use full AI capabilities with streaming, add your OpenAI API key to the `.env
 
 ```
 aiva-backend/
-├── app.py                 # Main FastAPI application with fashion catalog
-├── ai_service.py         # OpenAI integration with Italian support
+├── api/index.py         # Serverless entrypoint for Vercel
+├── app.py               # Main FastAPI application with fashion catalog
+├── ai_service.py        # OpenAI integration with Italian support
 ├── run.py               # Server startup script
 ├── test_api.py          # API test suite
 ├── requirements.txt     # Python dependencies
-├── .env.example        # Environment variables template
-├── .env               # Your environment variables (create this)
-└── README.md          # This file
+├── .env.example         # Environment variables template
+├── .env                 # Your environment variables (create this)
+└── README.md            # This file
 ```
+
+### Vercel Deployment Notes
+
+- Imposta la **Root Directory** del progetto Vercel su `aiva-backend`.
+- Vercel utilizza `api/index.py` come entrypoint serverless e inoltra tutte le
+  richieste HTTP a FastAPI tramite la route definita in `vercel.json`.
+- Assicurati che le variabili di ambiente (es. `ALLOWED_ORIGINS`,
+  `OPENAI_API_KEY`, `PUBLIC_BASE_URL`) siano configurate nel progetto Vercel.
 
 ## 🔌 API Endpoints
 

--- a/aiva-backend/api/index.py
+++ b/aiva-backend/api/index.py
@@ -1,0 +1,7 @@
+"""Serverless entrypoint for Vercel deployment.
+
+This module exposes the FastAPI ``app`` object defined in :mod:`app` so that
+Vercel's Python runtime can import it as an ASGI handler.
+"""
+
+from app import app  # noqa: F401

--- a/aiva-backend/vercel.json
+++ b/aiva-backend/vercel.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
-  "builds": [{ "src": "main.py", "use": "@vercel/python" }],
-  "routes": [{ "src": "/(.*)", "dest": "/main.py" }]
+  "builds": [{ "src": "api/index.py", "use": "@vercel/python" }],
+  "routes": [{ "src": "/(.*)", "dest": "/api/index.py" }]
 }


### PR DESCRIPTION
## Summary
- add a dedicated `api/index.py` entrypoint for the backend so Vercel can package the FastAPI app
- update the backend `vercel.json` to build and route requests through the new serverless function
- document the monorepo/Vercel setup requirements in the backend README

## Testing
- pytest -q *(fails: fixture 'client' not found in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68ca766ebbd08320bfc1166201b1350c