### PR TITLE
Improve cart persistence and voice category handling

### DIFF
--- a/AIVA - Complete Implementation Summary.md
+++ b/AIVA - Complete Implementation Summary.md
@@ -98,6 +98,14 @@
 
 ---
 
+## 🔧 Latest Enhancements
+
+- 🛒 **Cart resilienza lato client**: Lo stato del carrello ora sopravvive ai refresh anche quando il backend serverless torna vuoto, grazie ad una sincronizzazione che privilegia i dati persistiti localmente e ripubblica lo snapshot al rehydrate.
+- 🎙️ **Comprensione categorie potenziata**: L'assistente vocale riconosce subito richieste come “mostrami le scarpe” applicando automaticamente i filtri UI e la ricerca della categoria corretta, anche in fallback offline.
+- 🏷️ **Offerte con variante rapida**: Il pulsante “add to cart” delle card in offerta apre lo stesso selettore taglia/colore della pagina prodotti prima di aggiungere l'articolo al carrello.
+
+---
+
 ## 📁 Project Structure
 
 ```

--- a/aiva-frontend/README.MD
+++ b/aiva-frontend/README.MD
@@ -12,6 +12,7 @@ Modern, responsive React frontend for AIVA Fashion - an AI-powered voice shoppin
 - 🔊 **Text-to-Speech**: AI responses spoken back to the user
 - 📊 **Voice Visualizer**: Real-time audio level visualization
 - 💬 **Chat Interface**: Visual conversation history with AI
+- 🧠 **Category-aware Commands**: L'assistente riconosce richieste come "mostrami le scarpe" applicando automaticamente filtri e ricerca di categoria.
 
 ### E-commerce Features
 - 🛍️ **Product Catalog**: 30+ fashion items with variants
@@ -20,6 +21,8 @@ Modern, responsive React frontend for AIVA Fashion - an AI-powered voice shoppin
 - 💳 **Checkout Flow**: Complete purchase process
 - ⭐ **Product Reviews**: Ratings and reviews display
 - 🏷️ **Promotions**: Discount badges and sale prices
+- 🛡️ **Persistenza Carrello**: Il carrello resta disponibile tra i refresh anche con backend stateless grazie alla sincronizzazione locale.
+- 🏷️ **Quick Add Offerte**: Le card della sezione offerte aprono il selettore di taglia e colore prima di aggiungere al carrello.
 
 ### UI/UX Excellence
 - 📱 **Fully Responsive**: Adapts to all screen sizes

--- a/aiva-frontend/src/hooks/useVoiceAssistantNative.js
+++ b/aiva-frontend/src/hooks/useVoiceAssistantNative.js
@@ -258,45 +258,47 @@ export const useVoiceAssistantNative = () => {
   const INTERACTION_CHECK_INTERVAL = 15000; // Check every 10 seconds
 
   // Welcome messages
-const getWelcomeMessage = useCallback(() => {
-  const welcomeMessages = [
-    // --- Set 1: Chiare e dirette ---
-    "Ciao! Sono AIVA, la tua personal shopper AI. Come posso aiutarti oggi?",
-    "Benvenuto. Sono AIVA, qui per aiutarti a navigare tra le nostre collezioni. Cerchi ispirazione o hai già un'idea precisa?",
-    "Ciao! Sono AIVA, l'assistente AI pronta a trasformare la tua esperienza di shopping. Cosa posso fare per te?",
+  const getWelcomeMessage = useCallback(() => {
+    const welcomeMessages = [
+      // --- Set 1: Chiare e dirette ---
+      "Ciao! Sono AIVA, la tua personal shopper AI. Come posso aiutarti oggi?",
+      "Benvenuto. Sono AIVA, qui per aiutarti a navigare tra le nostre collezioni. Cerchi ispirazione o hai già un'idea precisa?",
+      "Ciao! Sono AIVA, l'assistente AI pronta a trasformare la tua esperienza di shopping. Cosa posso fare per te?",
 
-    // --- Set 2: Creative e ispirazionali ---
-    "Benvenuto nel nostro ecommerce. Sono AIVA, la tua personal shopper AI. Quali prodotti ti piacerebbe vedere?",
-    "Sono AIVA, la tua assistente allo shopping. Insieme possiamo scoprire le nuove collezioni o trovare esattamente ciò che desideri. Da dove vogliamo cominciare?",
+      // --- Set 2: Creative e ispirazionali ---
+      "Benvenuto nel nostro ecommerce. Sono AIVA, la tua personal shopper AI. Quali prodotti ti piacerebbe vedere?",
+      "Sono AIVA, la tua assistente allo shopping. Insieme possiamo scoprire le nuove collezioni o trovare esattamente ciò che desideri. Da dove vogliamo cominciare?",
 
-    // --- Set 3: Guidate e interattive ---
-    "Benvenuto! Sono AIVA e sono qui per aiutarti a trovare l'outfit perfetto. Puoi dirmi cosa cerchi oppure chiedermi di mostrarti le ultime offerte."
-  ];
+      // --- Set 3: Guidate e interattive ---
+      "Benvenuto! Sono AIVA e sono qui per aiutarti a trovare l'outfit perfetto. Puoi dirmi cosa cerchi oppure chiedermi di mostrarti le ultime offerte."
+    ];
 
-  const shortMessages = [
-    // --- Set 1: Rapide e dirette ---
-    "Eccomi di nuovo.",
-    "Rieccomi.",
-    "Bentornato.",
-    "Sono di nuovo qui. Dimmi pure.",
+    const shortMessages = [
+      // --- Set 1: Rapide e dirette ---
+      "Eccomi di nuovo.",
+      "Rieccomi.",
+      "Bentornato.",
+      "Sono di nuovo qui. Dimmi pure.",
 
-    // --- Set 2: Contestuali e propositive ---
-    "Pronta a continuare. Hai trovato qualcosa che ti piace o cerchiamo altro?",
+      // --- Set 2: Contestuali e propositive ---
+      "Pronta a continuare. Hai trovato qualcosa che ti piace o cerchiamo altro?",
 
-    // --- Set 3: Amichevoli e concise ---
-    "Ok, continuiamo. Cosa facciamo ora?",
-    "Pronti a ripartire. Ti ascolto."
-  ];
+      // --- Set 3: Amichevoli e concise ---
+      "Ok, continuiamo. Cosa facciamo ora?",
+      "Pronti a ripartire. Ti ascolto."
+    ];
 
-  // Logic to select and return a message would go here...
-});
-    
+    const pickRandom = (messages) => {
+      if (!messages || messages.length === 0) return '';
+      return messages[Math.floor(Math.random() * messages.length)] || '';
+    };
+
     if (sessionCount === 0) {
       setSessionCount(1);
-      return welcomeMessages[Math.floor(Math.random() * welcomeMessages.length)];
-    } else {
-      return shortMessages[Math.floor(Math.random() * shortMessages.length)];
+      return pickRandom(welcomeMessages);
     }
+
+    return pickRandom(shortMessages);
   }, [sessionCount]);
 
   // Browser support check


### PR DESCRIPTION
## Summary
- keep locally persisted carts from being wiped when the stateless backend returns an empty payload and republish the snapshot on rehydrate
- teach the AI service (including the offline fallback) to detect Italian product categories and automatically apply UI filters when the user asks for a specific section
- align the offers page “add to cart” flow with the product catalogue quick-add modal and document the new behaviours, including fixing the welcome message helper so builds succeed

## Testing
- npm run build
- pytest *(fails: fixture 'client' not found in test_api.py)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1bcaf7c48320b42ad57bc42b89cc