### PR TITLE
Improve TTS streaming and unlock stuck microphone turns

### DIFF
--- a/AIVA - Complete Implementation Summary.md
+++ b/AIVA - Complete Implementation Summary.md
@@ -98,6 +98,17 @@
 
 ---
 
+## 🔧 Latest Enhancements
+
+- 🗣️ **Descrizioni naturali e veloci**: il backend fornisce al modello un contesto ridotto alle informazioni moda rilevanti, imponendo risposte che raccontano stile e materiali senza elenchi di magazzino; la pipeline di streaming ora ricompone le frasi e le mette in coda con volume uniforme così la voce sintetica le legge in modo fluido e senza cali.
+- 💬 **Memoria di sessione compatta**: il frontend conserva gli ultimi turni utente/assistente (fino a 12 scambi) e li inoltra ad ogni richiesta; il backend li sanifica e li riutilizza, garantendo continuità di conversazione senza gonfiare il contesto.
+- 🛒 **Comandi multi-pezzo affidabili**: richieste come “aggiungi due taglie L rosso e una S bianca” vengono parse prima di chiamare l'LLM, generando più add_to_cart con verifica di varianti disponibili e un riepilogo parlato.
+- 🎧 **Esperienza voice fail-safe**: il player TTS parla ogni chunk di frase in coda, mantiene il lock finché l'ultimo pezzo è pronunciato e registra comunque la risposta nel log conversazionale anche quando arriva in streaming.
+- 🎙️ **Microfono sempre pronto**: il turno viene rilasciato automaticamente dopo i messaggi locali (es. lettura del carrello) così l'assistente riapre il microfono appena finisce di parlare.
+- 🔁 **Gestione turni a prova di blocco**: i controlli su “turno in corso” ora si azzerano alla fine delle risposte vocali evitando che comandi successivi vengano ignorati.
+
+---
+
 ## 📁 Project Structure
 
 ```

--- a/aiva-frontend/README.MD
+++ b/aiva-frontend/README.MD
@@ -12,6 +12,10 @@ Modern, responsive React frontend for AIVA Fashion - an AI-powered voice shoppin
 - 🔊 **Text-to-Speech**: AI responses spoken back to the user
 - 📊 **Voice Visualizer**: Real-time audio level visualization
 - 💬 **Chat Interface**: Visual conversation history with AI
+- 🧠 **Category-aware Commands**: L'assistente riconosce richieste come "mostrami le scarpe" applicando automaticamente filtri e ricerca di categoria.
+- 📚 **Session Memory**: Gli ultimi turni vengono preservati e reinviati al backend per risposte coerenti.
+- 🗣️ **Streaming fluido**: L'audio sintetizzato ricompone le frasi, le livella nel volume e le legge senza l'effetto "token-by-token".
+- 🎙️ **Microfono sempre attivo**: Dopo ogni risposta locale (es. riepilogo carrello) il lock vocale viene rilasciato e l'assistente torna subito in ascolto.
 
 ### E-commerce Features
 - 🛍️ **Product Catalog**: 30+ fashion items with variants
@@ -20,6 +24,9 @@ Modern, responsive React frontend for AIVA Fashion - an AI-powered voice shoppin
 - 💳 **Checkout Flow**: Complete purchase process
 - ⭐ **Product Reviews**: Ratings and reviews display
 - 🏷️ **Promotions**: Discount badges and sale prices
+- 🛡️ **Persistenza Carrello**: Il carrello resta disponibile tra i refresh anche con backend stateless grazie alla sincronizzazione locale.
+- 🏷️ **Quick Add Offerte**: Le card della sezione offerte aprono il selettore di taglia e colore prima di aggiungere al carrello.
+- ➕ **Comandi multi-pezzo**: Una singola frase può aggiungere più varianti (es. "due L rosso e una S bianca") con validazione immediata.
 
 ### UI/UX Excellence
 - 📱 **Fully Responsive**: Adapts to all screen sizes
@@ -71,7 +78,7 @@ The app will open at `http://localhost:5173`
 ### Voice Features
 - **Web Speech API (ASR/TTS)** - Riconoscimento e sintesi nativi
 - **TTS Queue + Barge‑in** - Coda di frasi con chaining e interruzione RMS
-- **WebSocket** - Messaggi strutturati (response/complete, function_*). Nessun text_chunk lato UI
+- **WebSocket** - Messaggi strutturati (response/complete, function_*, stream_start/text_chunk/stream_complete) per streaming a frasi complete.
 
 ### State & Data
 - **Zustand** - State management


### PR DESCRIPTION
## Summary
- buffer streaming responses into sentence-level TTS chunks so the speech engine keeps a consistent volume and skips duplicating the final answer when streaming finishes
- release the voice turn after local cart summaries so the assistant immediately reopens the microphone instead of leaving users stuck on “turno in corso”
- document the smoother audio playback and automatic microphone recovery in the implementation overview and frontend README

## Testing
- npm run build --prefix aiva-frontend
- pytest *(fails: fixture `client` missing in test_api.py)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1bcaf7c48320b42ad57bc42b89cc