### PR TITLE
Refine session-aware cart handling and voice UX

### DIFF
--- a/aiva-frontend/src/utils/session.js
+++ b/aiva-frontend/src/utils/session.js
@@ -1,0 +1,46 @@
+// src/utils/session.js - shared session helpers
+
+const STORAGE_KEY = 'aiva_session_id';
+const GLOBAL_KEY = '__AIVA_SESSION_ID__';
+export const SESSION_HEADER = 'X-Session-Id';
+
+const generateSessionId = () => {
+  return `sess-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+export function getSessionId() {
+  if (typeof window === 'undefined') return null;
+
+  if (window[GLOBAL_KEY]) return window[GLOBAL_KEY];
+
+  let stored = null;
+  try {
+    stored = window.localStorage?.getItem(STORAGE_KEY) || null;
+  } catch (err) {
+    stored = null;
+  }
+
+  if (!stored) {
+    stored = generateSessionId();
+    try {
+      window.localStorage?.setItem(STORAGE_KEY, stored);
+    } catch (err) {
+      // Ignore storage errors (e.g. Safari private mode)
+    }
+  }
+
+  window[GLOBAL_KEY] = stored;
+  return stored;
+}
+
+export function withSessionHeaders(init = {}) {
+  const sessionId = getSessionId();
+  if (!sessionId) return { ...init };
+
+  const headers = { ...(init.headers || {}) };
+  if (!headers[SESSION_HEADER]) {
+    headers[SESSION_HEADER] = sessionId;
+  }
+
+  return { ...init, headers };
+}


### PR DESCRIPTION
## Summary
- introduce a browser-persistent session id helper and attach it to all frontend cart and voice requests
- refactor the backend data store and cart endpoints to resolve per-session carts and set a lightweight session cookie
- improve the voice assistant’s acknowledgements, product description trigger, quantity/color parsing, and ASR timeout handling

## Testing
- pytest aiva-backend/test_api.py *(fails: fixture 'client' not found in upstream test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68cb38e8a49c8320a6d98cf4ce0c19bc