### PR TITLE
Improve voice assistant listening flow

### DIFF
--- a/aiva-frontend/src/pages/ProductPage.jsx
+++ b/aiva-frontend/src/pages/ProductPage.jsx
@@ -50,18 +50,31 @@ const ProductPage = () => {
             .replace(/\s{2,}/g, ' ')
             .trim();
 
+        const sanitizedDescription = stripMd(
+          productData.description_long || productData.description || ''
+        );
+
         window.currentProductContext = {
           id: productData.id,
           name: productData.name,
-          description_text: stripMd(productData.description || productData.description_long || ''),
+          description_text: sanitizedDescription,
           category: productData.category,
           gender: productData.gender,
+          price: productData.price,
+          brand: productData.brand,
+          image: productData.image,
           variants: (productData.variants || []).map((v) => ({
-            size: v.size,
+            size: typeof v.size === 'string' ? v.size : v.size?.value,
             color: v.color,
             available: v.available,
             stock: v.stock,
           })),
+          product: {
+            ...productData,
+            description: productData.description,
+            description_long: productData.description_long,
+          },
+          lastUpdated: Date.now(),
         };
         // Set default selections
         if (productData.variants && productData.variants.length > 0) {


### PR DESCRIPTION
## Summary
- introduce listening profiles with profile-specific inactivity windows and prompt pools to make no-input handling adapt to the current conversation
- buffer final speech recognition results with a short grace period so multi-phrase utterances are captured before the microphone is stopped
- apply conversation heuristics across speech synthesis, command handling, and assistant start-up to set the appropriate profile for follow-ups or ongoing tasks

## Testing
- npm run build
- npm run lint *(fails: ESLint configuration file is missing in the project scaffold)*
- pytest *(fails: httpx AsyncClient fixture is not defined in the suite)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4230285c8320925e2f2834c0b9f0