### PR TITLE
Add server speech fallback and offline TTS pipeline

### DIFF
--- a/aiva-backend/README.MD
+++ b/aiva-backend/README.MD
@@ -91,6 +91,10 @@ Once the server is running, you can access:
 | `ALLOWED_ORIGIN_REGEX` | Override/disable the default `https://*.vercel.app` allowance (`false` to disable) | `https://.*\\.vercel\\.app` |
 | `MAX_REQUESTS_PER_MINUTE` | General rate limit | `60` |
 | `MAX_AI_REQUESTS_PER_MINUTE` | AI endpoint rate limit | `10` |
+| `VOSK_MODEL_PATH` | Filesystem path to the Italian Vosk model (`vosk-model-small-it-0.22`) used for offline STT fallback | None (disable)
+| `PYTTSX3_VOICE` | Optional voice id/name passed to `pyttsx3` for offline TTS | autodetect Italian voice |
+| `PYTTSX3_RATE` | Playback rate for offline TTS | `170` |
+| `PYTTSX3_VOLUME` | Playback volume for offline TTS | `1.0` |
 | `PORT` | Server port | `8000` |
 | `HOST` | Server host | `0.0.0.0` |
 
@@ -103,6 +107,16 @@ The backend can run without an OpenAI API key using fallback mode:
 - Pre-defined response patterns in Italian
 
 To use full AI capabilities with streaming, add your OpenAI API key to the `.env` file.
+
+### Offline Speech Stack (Mobile iOS fallback)
+
+To support Safari/Chrome mobile where the Web Speech API is unavailable, configure the server-side speech stack:
+
+1. **Install Vosk Italian model** – download [`vosk-model-small-it-0.22`](https://alphacephei.com/vosk/models) and unpack it.
+2. **Expose the path** – set `VOSK_MODEL_PATH=/var/task/models/vosk-model-small-it-0.22` (or the deployed path) so the backend can load it lazily.
+3. **Optional TTS tuning** – adjust `PYTTSX3_VOICE`, `PYTTSX3_RATE`, `PYTTSX3_VOLUME` to select a system voice for `pyttsx3`. When the engine is not available the service automatically falls back to `gTTS`.
+
+The new `/api/speech-to-text` and `/api/tts` endpoints are designed for PCM16 audio chunks (`base64`) and return JSON payloads usable by the frontend fallback pipeline.
 
 ## 🛡️ Security Features
 
@@ -152,6 +166,9 @@ aiva-backend/
 
 ### Voice/AI Endpoints
 - `POST /api/voice/process` - Elaborazione comandi vocali (Italiano)
+- `POST /api/voice/command` - Endpoint Vercel-friendly che restituisce l'intero turno in un'unica risposta
+- `POST /api/speech-to-text` - Trascrizione server-side di audio PCM16 (`base64`) tramite modello Vosk
+- `POST /api/tts` - Sintesi vocale offline (pyttsx3/gTTS) con risposta `audio_base64`
 
 ### Product Endpoints
 - `GET /api/products` - List products with advanced filtering

--- a/aiva-backend/requirements.txt
+++ b/aiva-backend/requirements.txt
@@ -40,6 +40,12 @@ orjson==3.9.10
 # Logging
 colorlog==6.8.0
 
+# Offline speech stack (server-side fallback)
+vosk==0.3.45
+numpy==1.26.2
+pyttsx3==2.90
+gTTS==2.5.1
+
 # Rate limiting
 slowapi==0.1.9
 

--- a/aiva-backend/speech_service.py
+++ b/aiva-backend/speech_service.py
@@ -1,0 +1,161 @@
+"""Server-side speech-to-text fallback utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+logger = logging.getLogger("AIVA.STT")
+
+
+try:  # pragma: no cover - optional dependency may be missing in CI
+    from vosk import KaldiRecognizer, Model  # type: ignore
+except Exception:  # pragma: no cover - gracefully degrade when unavailable
+    KaldiRecognizer = None  # type: ignore
+    Model = None  # type: ignore
+
+
+class _LazyModel:
+    """Lazy Vosk model loader guarded by an asyncio lock."""
+
+    def __init__(self) -> None:
+        self._model: Optional[Model] = None
+        self._lock = asyncio.Lock()
+        self._load_failed = False
+
+    async def get(self) -> Optional[Model]:
+        if self._model or self._load_failed:
+            return self._model
+
+        async with self._lock:
+            if self._model or self._load_failed:
+                return self._model
+
+            if Model is None:
+                logger.warning("Vosk is not available - STT fallback disabled")
+                self._load_failed = True
+                return None
+
+            model_path = os.getenv("VOSK_MODEL_PATH")
+            if not model_path:
+                logger.warning(
+                    "VOSK_MODEL_PATH not configured - unable to enable offline STT"
+                )
+                self._load_failed = True
+                return None
+
+            if not os.path.isdir(model_path):
+                logger.error("VOSK model path %s does not exist", model_path)
+                self._load_failed = True
+                return None
+
+            loop = asyncio.get_running_loop()
+
+            def _load_model() -> Model:
+                logger.info("Loading Vosk model from %s", model_path)
+                return Model(model_path)  # type: ignore[call-arg]
+
+            try:
+                self._model = await loop.run_in_executor(None, _load_model)
+                logger.info("Vosk model loaded successfully")
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.exception("Failed to load Vosk model: %s", exc)
+                self._load_failed = True
+                self._model = None
+
+        return self._model
+
+
+_MODEL = _LazyModel()
+
+
+@dataclass(slots=True)
+class SpeechToTextResult:
+    text: str
+    confidence: float = 0.0
+    success: bool = True
+    reason: Optional[str] = None
+
+
+def _pcm16_from_base64(payload: str) -> bytes:
+    try:
+        return base64.b64decode(payload)
+    except Exception as exc:  # pragma: no cover - invalid payload handling
+        raise ValueError("Invalid base64 audio payload") from exc
+
+
+async def transcribe_pcm16(
+    audio_base64: str,
+    sample_rate: int = 16000,
+    language: str = "it-IT",
+) -> SpeechToTextResult:
+    """Transcribe a PCM16 mono audio buffer using Vosk when available."""
+
+    model = await _MODEL.get()
+    if not model:
+        return SpeechToTextResult(
+            text="",
+            confidence=0.0,
+            success=False,
+            reason="offline_model_unavailable",
+        )
+
+    pcm_bytes = _pcm16_from_base64(audio_base64)
+    if not pcm_bytes:
+        return SpeechToTextResult(
+            text="",
+            confidence=0.0,
+            success=False,
+            reason="empty_audio",
+        )
+
+    if sample_rate <= 0:
+        sample_rate = 16000
+
+    loop = asyncio.get_running_loop()
+
+    def _run_recognition() -> SpeechToTextResult:
+        recognizer = KaldiRecognizer(model, sample_rate)
+        recognizer.SetWords(True)
+
+        # Feed audio in chunks of 4k to keep memory usage tiny
+        view = memoryview(pcm_bytes)
+        step = 4000
+        for offset in range(0, len(pcm_bytes), step):
+            recognizer.AcceptWaveform(bytes(view[offset : offset + step]))
+
+        result_json = recognizer.FinalResult()
+        try:
+            parsed = json.loads(result_json)
+        except json.JSONDecodeError:
+            parsed = {"text": ""}
+
+        text = parsed.get("text", "").strip()
+        confidence = 0.0
+        if text:
+            words = parsed.get("result") or []
+            if isinstance(words, list) and words:
+                confidences = [w.get("conf", 0.0) for w in words if isinstance(w, dict)]
+                if confidences:
+                    confidence = float(np.mean(confidences))
+
+        return SpeechToTextResult(text=text, confidence=confidence, success=True)
+
+    try:
+        return await loop.run_in_executor(None, _run_recognition)
+    except Exception as exc:  # pragma: no cover - unexpected runtime issues
+        logger.exception("STT processing failed: %s", exc)
+        return SpeechToTextResult(
+            text="",
+            confidence=0.0,
+            success=False,
+            reason="processing_error",
+        )
+

--- a/aiva-backend/tts_service.py
+++ b/aiva-backend/tts_service.py
@@ -1,0 +1,195 @@
+"""Server-side text-to-speech helper leveraging offline/open-source engines."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("AIVA.TTS")
+
+
+try:  # pragma: no cover - optional dependency handling
+    import pyttsx3  # type: ignore
+except Exception:  # pragma: no cover - fallback when dependency missing
+    pyttsx3 = None  # type: ignore
+
+
+try:  # pragma: no cover - optional dependency handling
+    from gtts import gTTS  # type: ignore
+except Exception:  # pragma: no cover
+    gTTS = None  # type: ignore
+
+
+@dataclass(slots=True)
+class TTSResult:
+    audio_base64: str
+    mime_type: str
+    success: bool = True
+    reason: Optional[str] = None
+
+
+class OfflineTTSEngine:
+    """Wrapper that attempts pyttsx3 first and falls back to gTTS."""
+
+    def __init__(self) -> None:
+        self._engine = None
+        self._engine_lock = asyncio.Lock()
+        self._engine_ready = False
+        self._engine_failed = False
+
+    async def _ensure_engine(self) -> Optional[object]:
+        if self._engine_ready:
+            return self._engine
+        if self._engine_failed:
+            return None
+
+        async with self._engine_lock:
+            if self._engine_ready:
+                return self._engine
+            if self._engine_failed:
+                return None
+
+            if pyttsx3 is None:
+                logger.warning("pyttsx3 not available - skipping offline engine")
+                self._engine_failed = True
+                return None
+
+            loop = asyncio.get_running_loop()
+
+            def _init_engine():
+                engine = pyttsx3.init()
+                # Ensure Italian voice preference when available
+                preferred_voice = os.getenv("PYTTSX3_VOICE", "it")
+                for voice in engine.getProperty("voices"):
+                    name = getattr(voice, "name", "") or ""
+                    lang = "".join(getattr(voice, "languages", []) or [])
+                    if preferred_voice.lower() in name.lower() or preferred_voice in lang.lower():
+                        engine.setProperty("voice", voice.id)
+                        break
+                engine.setProperty("rate", int(os.getenv("PYTTSX3_RATE", "170")))
+                engine.setProperty("volume", float(os.getenv("PYTTSX3_VOLUME", "1.0")))
+                return engine
+
+            try:
+                self._engine = await loop.run_in_executor(None, _init_engine)
+                self._engine_ready = True
+            except Exception as exc:  # pragma: no cover - environment specific
+                logger.exception("Unable to initialise pyttsx3 engine: %s", exc)
+                self._engine_failed = True
+                self._engine = None
+
+        return self._engine
+
+    async def synthesize(self, text: str, voice: Optional[str] = None) -> Optional[TTSResult]:
+        if not text.strip():
+            return TTSResult(audio_base64="", mime_type="audio/wav", success=False, reason="empty_text")
+
+        engine = await self._ensure_engine()
+        if engine is None:
+            return None
+
+        loop = asyncio.get_running_loop()
+
+        def _render_to_bytes() -> Optional[bytes]:
+            tmp_path = Path(tempfile.mkstemp(suffix=".wav")[1])
+            try:
+                if voice:
+                    try:
+                        engine.setProperty("voice", voice)
+                    except Exception:  # pragma: no cover
+                        logger.debug("Requested voice %s not available", voice)
+
+                engine.save_to_file(text, str(tmp_path))
+                engine.runAndWait()
+                if not tmp_path.exists():
+                    return None
+                return tmp_path.read_bytes()
+            finally:
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+
+        audio_bytes = await loop.run_in_executor(None, _render_to_bytes)
+        if not audio_bytes:
+            return None
+
+        return TTSResult(
+            audio_base64=base64.b64encode(audio_bytes).decode("ascii"),
+            mime_type="audio/wav",
+            success=True,
+        )
+
+
+class GTTSFallback:
+    """Optional network-based fallback using Google's unofficial endpoint."""
+
+    @staticmethod
+    async def synthesize(text: str, lang: str = "it") -> Optional[TTSResult]:
+        if gTTS is None:
+            return None
+        if not text.strip():
+            return TTSResult(audio_base64="", mime_type="audio/mpeg", success=False, reason="empty_text")
+
+        loop = asyncio.get_running_loop()
+
+        def _render_mp3() -> Optional[bytes]:
+            with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
+                tmp_path = Path(tmp.name)
+            try:
+                tts = gTTS(text=text, lang=lang)
+                tts.save(str(tmp_path))
+                return tmp_path.read_bytes()
+            except Exception as exc:  # pragma: no cover - depends on network
+                logger.error("gTTS synthesis failed: %s", exc)
+                return None
+            finally:
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+
+        audio_bytes = await loop.run_in_executor(None, _render_mp3)
+        if not audio_bytes:
+            return None
+
+        return TTSResult(
+            audio_base64=base64.b64encode(audio_bytes).decode("ascii"),
+            mime_type="audio/mpeg",
+            success=True,
+        )
+
+
+_offline_tts = OfflineTTSEngine()
+
+
+async def synthesize_speech(text: str, voice: Optional[str] = None) -> TTSResult:
+    """Generate speech audio using offline engine or fallback network TTS."""
+
+    try:
+        offline_result = await _offline_tts.synthesize(text, voice=voice)
+    except Exception as exc:  # pragma: no cover
+        logger.exception("Offline TTS synthesis raised an error: %s", exc)
+        offline_result = None
+
+    if offline_result and offline_result.success:
+        return offline_result
+
+    # Fallback to gTTS when offline engine unavailable
+    try:
+        fallback_lang = (voice or "it").split("-")[0]
+        gtts_result = await GTTSFallback.synthesize(text, lang=fallback_lang or "it")
+        if gtts_result:
+            return gtts_result
+    except Exception as exc:  # pragma: no cover
+        logger.exception("gTTS fallback failed: %s", exc)
+
+    reason = offline_result.reason if offline_result else "tts_unavailable"
+    return TTSResult(audio_base64="", mime_type="audio/wav", success=False, reason=reason)
+

--- a/aiva-frontend/README.MD
+++ b/aiva-frontend/README.MD
@@ -78,6 +78,7 @@ The app will open at `http://localhost:5173`
 
 ### Voice Features
 - **Web Speech API (ASR/TTS)** - Riconoscimento e sintesi nativi
+- **Server fallback STT/TTS** - Invio PCM16 al backend (`/api/speech-to-text`) con riproduzione audio da `/api/tts` su iOS/Safari
 - **TTS Queue + Barge‑in** - Coda di frasi con chaining e interruzione RMS
 - **WebSocket** - Messaggi strutturati (response/complete, function_*, stream_start/text_chunk/stream_complete) per streaming a frasi complete.
 
@@ -154,6 +155,14 @@ const assistant = useVoiceAssistantNative();
 VITE_BACKEND_URL=http://localhost:8000
 VITE_WS_URL=ws://localhost:8000
 ```
+
+### Mobile Speech Fallback
+
+Su iOS/Safari il browser non espone `webkitSpeechRecognition`: il frontend usa automaticamente il percorso server-side inviando chunk PCM16 al backend e riproducendo l'audio restituito da `/api/tts`. Per un'esperienza completa:
+
+1. Configura il backend con `VOSK_MODEL_PATH` (modello italiano) e le variabili opzionali `PYTTSX3_*`.
+2. Assicurati che il microfono sia autorizzato: il hook crea una `AudioContext` e ricampionamento a 16 kHz prima dell'upload.
+3. Verifica che `VITE_BACKEND_URL` sia raggiungibile via HTTPS su mobile (richiesto da getUserMedia).
 
 ### Tailwind Customization
 The design system includes:

--- a/aiva-frontend/src/services/api.js
+++ b/aiva-frontend/src/services/api.js
@@ -191,6 +191,49 @@ export const voiceAPI = {
     );
     if (!res.ok) throw new Error(`POST /voice/command ${res.status}`);
     return res.json();
+  },
+
+  async transcribeAudio({ audio, sampleRate = 16000, language = 'it-IT', sessionId } = {}) {
+    const resolvedSessionId = sessionId || getSessionId();
+    const payload = {
+      audio,
+      sample_rate: sampleRate,
+      language,
+      session_id: resolvedSessionId
+    };
+
+    const res = await fetch(
+      `${API_BASE}/speech-to-text`,
+      withSessionHeaders({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload)
+      })
+    );
+    if (!res.ok) throw new Error(`POST /speech-to-text ${res.status}`);
+    return res.json();
+  },
+
+  async synthesizeSpeech({ text, voice, sessionId } = {}) {
+    const resolvedSessionId = sessionId || getSessionId();
+    const payload = {
+      text,
+      voice,
+      session_id: resolvedSessionId
+    };
+
+    const res = await fetch(
+      `${API_BASE}/tts`,
+      withSessionHeaders({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload)
+      })
+    );
+    if (!res.ok) throw new Error(`POST /tts ${res.status}`);
+    return res.json();
   }
 };
 


### PR DESCRIPTION
## Summary
- add optional Vosk-powered `/api/speech-to-text` endpoint and offline `/api/tts` service with new dependencies
- update the React voice hook to capture PCM on iOS, call the new APIs, and stream backend audio with an AudioContext player
- document the new configuration for the server speech stack and client fallback

## Testing
- npm run build
- pytest *(fails: missing httpx AsyncClient fixture in existing test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68cb440c73808320b86a08ff984c6269