### PR TITLE
Fix hook dependency order to avoid TDZ errors

### DIFF
--- a/aiva-frontend/src/hooks/useVoiceAssistantNative.js
+++ b/aiva-frontend/src/hooks/useVoiceAssistantNative.js
@@ -226,6 +226,14 @@ export const useVoiceAssistantNative = () => {
     if (isIOSDevice) return true;
     return false;
   }, [isBrowser, isIOSDevice]);
+
+  const isOutputSpeaking = useCallback(() => {
+    const synthSpeaking =
+      typeof window !== 'undefined' && window.speechSynthesis
+        ? window.speechSynthesis.speaking
+        : false;
+    return synthSpeaking || serverTTSActiveRef.current;
+  }, []);
   // 🔊 Barge-in RMS
   const bargeInCtxRef = useRef(null);
   const bargeInStreamRef = useRef(null);
@@ -1278,14 +1286,6 @@ export const useVoiceAssistantNative = () => {
       filterProducts(filters);
     }, 300);
   }, [filterProducts]);
-
-  const isOutputSpeaking = useCallback(() => {
-    const synthSpeaking =
-      typeof window !== 'undefined' && window.speechSynthesis
-        ? window.speechSynthesis.speaking
-        : false;
-    return synthSpeaking || serverTTSActiveRef.current;
-  }, []);
 
   const createServerRecognition = useCallback(() => {
     if (!shouldUseServerSTT) return null;


### PR DESCRIPTION
## Summary
- move the `isOutputSpeaking` callback definition before any hook dependencies that reference it
- remove the duplicate later definition so release and queue handlers can access the callback safely

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint configuration file missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcf693e7883209059bf64a40ebfaa